### PR TITLE
[REF] Disable gradients if possible

### DIFF
--- a/hessianfree/optimizer.py
+++ b/hessianfree/optimizer.py
@@ -1,5 +1,6 @@
 """Pytorch implementation of the Hessian-free optimizer."""
 
+from contextlib import nullcontext
 from warnings import warn
 
 import torch
@@ -213,7 +214,13 @@ class HessianFree(torch.optim.Optimizer):
             self._test_forward_determinisitc(forward)
 
         # Forward pass
-        loss, outputs = forward()
+        # for custom `mvp`s and gradients, loss and outputs can be non-differentiable
+        with (
+            torch.no_grad()
+            if grad is not None and mvp is not None
+            else nullcontext()
+        ):
+            loss, outputs = forward()
         init_loss = loss.item()
         if self.verbose:
             print(f"\nInitial loss = {init_loss:.6f}")


### PR DESCRIPTION
Hi,

I am using your optimizer and setting up the curvature matrix-vector products (`mvp`) and the gradients (`grad`) of the `step` function myself. In that case, one can turn off the autodiff when evaluating the loss and model output inside the optimizer, which should reduce memory because the computation graph will not be stored.

**Note 1:** I was executing the tests, and got the following fails (both seem to be unrelated to the lines I changed):
```bash
FAILED tests/test_cg.py::test_cg_residuals[device = cpu-preconditioning = False-atol = 1.000000e-06-tol = 1.000000e-06-dim = 50-seed = 42] - AssertionError: cg did not converge.
FAILED tests/test_cg.py::test_cg_m_iters[device = cpu-preconditioning = False-x0 is None? 0.000000e+00-dim = 50-seed = 0] - AssertionError: Discrepancy between quadratic and `m_iters`
```

**Note 2:** I am using `contextlib.nullcontext()`, which was introduced in Python 3.7. Since Python 3.8 will be deprecated soon, I think this should not be a problem.